### PR TITLE
Lyrics will be return based on index with highest char count

### DIFF
--- a/lyrics/src/reducers/reducer_lyrics.js
+++ b/lyrics/src/reducers/reducer_lyrics.js
@@ -10,8 +10,24 @@ export default function(state = {}, action){
       return {...state, track: song}
     case FETCH_LYRICS:
       let lyrics = action.payload.data;
-      return {...state, lyrics: lyrics[0]}
+      let index = getLyricsIndex(lyrics);
+      return {...state, lyrics: lyrics[index]}
     default:
       return state;
   }
+}
+
+function getLyricsIndex(lyrics){
+  let correctLyrics = {
+    size: 0,
+    index: 0
+  };
+  for(let i = 0; i < lyrics.length; i++){
+    if(lyrics[i].length > correctLyrics.size){
+      correctLyrics.size = lyrics[i].length;
+      correctLyrics.index = i;
+    } 
+  }
+
+  return correctLyrics.index;
 }


### PR DESCRIPTION
This issue was brought up when searching for the song "Amigo Mujer" by Caloncho returned no lyrics on the Front End. Web scraper result was only returning the first index. Now it will return the index with the highest character count.